### PR TITLE
fix: ToastContainer가 상단에 노출되지 않던 것을 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -30,6 +30,19 @@
       "version": "1.2.10",
       "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.10.tgz",
       "integrity": "sha512-o0J30wqycjF5miWDKYKKzzOU1ZTLuA42HZ4HE7/zqTOc/jTLdQ5NhYWvsRQo45Nfi1KHoRdNhteSI4BAxTF1Pg=="
+    },
+    "node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "license": "ISC",
       "dependencies": {
         "@types/chrome": "^0.0.209"
+      },
+      "devDependencies": {
+        "typescript": "^4.9.5"
       }
     },
     "node_modules/@types/chrome": {
@@ -38,6 +41,19 @@
       "version": "1.2.10",
       "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.10.tgz",
       "integrity": "sha512-o0J30wqycjF5miWDKYKKzzOU1ZTLuA42HZ4HE7/zqTOc/jTLdQ5NhYWvsRQo45Nfi1KHoRdNhteSI4BAxTF1Pg=="
+    },
+    "node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
     }
   },
   "dependencies": {
@@ -67,6 +83,12 @@
       "version": "1.2.10",
       "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.10.tgz",
       "integrity": "sha512-o0J30wqycjF5miWDKYKKzzOU1ZTLuA42HZ4HE7/zqTOc/jTLdQ5NhYWvsRQo45Nfi1KHoRdNhteSI4BAxTF1Pg=="
+    },
+    "typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "tsc": "tsc"
   },
   "repository": {
     "type": "git",
@@ -19,5 +20,8 @@
   "homepage": "https://github.com/zigsong/youtube-goback-timestamp#readme",
   "dependencies": {
     "@types/chrome": "^0.0.209"
+  },
+  "devDependencies": {
+    "typescript": "^4.9.5"
   }
 }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,120 +1,96 @@
+"use strict";
 document.addEventListener("DOMContentLoaded", () => {
-  commentsContainerObserver.observe(document.body, {
-    childList: true,
-    subtree: true,
-  });
-});
-
-const observeOriginContainer = (
-  commentNode,
-  originContainer,
-  toastContainer
-) => {
-  const options = {
-    threshold: 1.0,
-  };
-
-  const observer = new IntersectionObserver((entries, observer) => {
-    entries.forEach((entry) => {
-      if (entry.isIntersecting) {
-        originContainer.insertBefore(
-          commentNode,
-          originContainer.lastElementChild
-        );
-        toastContainer.remove();
-        observer.unobserve(originContainer);
-      }
+    commentsContainerObserver.observe(document.body, {
+        childList: true,
+        subtree: true,
     });
-  }, options);
-
-  observer.observe(originContainer);
+});
+const observeOriginContainer = (commentNode, originContainer, toastContainer) => {
+    const options = {
+        threshold: 1.0,
+    };
+    const observer = new IntersectionObserver((entries, observer) => {
+        entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+                originContainer.insertBefore(commentNode, originContainer.lastElementChild);
+                toastContainer.remove();
+                observer.unobserve(originContainer);
+            }
+        });
+    }, options);
+    observer.observe(originContainer);
 };
-
+// const append = (target, parent) => {
+//   console.debug("불러짐?");
+//   console.debug("target", target);
+//   console.debug("parent", parent);
+//   toastContainer.innerHTML = "aweifjaweoifjwaefoiwaeofjwfei";
+//   console.debug(toastContainer);
+//   parent.appendChild(target.cloneNode());
+// };
 const handleClickTimeStamp = (commentNode, originContainer) => {
-  // MARK: copy할 수 있는 방안을 찾기
-  const bottomArea = document.querySelector("div#below");
-  const toastContainer = document.createElement("div");
-
-  toastContainer.setAttribute(
-    "style",
-    "width: 100%; border: 2px dashed #32A6FF; margin-top: 12px; padding: 12px; box-sizing: border-box; border-radius: 12px; cursor: pointer;"
-  );
-
-  toastContainer.addEventListener("mouseover", () => {
-    toastContainer.style.background = "rgba(50, 166, 255, 0.2)";
-  });
-
-  toastContainer.addEventListener("mouseout", () => {
-    toastContainer.style.background = "none";
-  });
-
-  toastContainer.appendChild(commentNode);
-  bottomArea.insertBefore(toastContainer, bottomArea.firstChild);
-
-  observeOriginContainer(commentNode, originContainer, toastContainer);
-
-  toastContainer.addEventListener(
-    "click",
-    () => {
-      originContainer.insertBefore(
-        commentNode,
-        originContainer.lastElementChild
-      );
-      originContainer.scrollIntoView({ behavior: "smooth", block: "center" });
-      toastContainer.remove();
-    },
-    { capture: true }
-  );
+    // MARK: copy할 수 있는 방안을 찾기
+    const bottomArea = document.querySelector("div#below");
+    const toastContainer = document.createElement("div");
+    toastContainer.setAttribute("style", "width: 100%; border: 2px dashed #32A6FF; margin-top: 12px; padding: 12px; box-sizing: border-box; border-radius: 12px; cursor: pointer;");
+    toastContainer.addEventListener("mouseover", () => {
+        toastContainer.style.background = "rgba(50, 166, 255, 0.2)";
+    });
+    // toastContainer.addEventListener("mouseout", () => {
+    //   toastContainer.style.background = "none";
+    // });
+    console.debug("toast containerr ", toastContainer);
+    console.debug("commentNode", commentNode);
+    // append(commentNode, toastContainer);
+    toastContainer.appendChild(commentNode);
+    bottomArea.insertBefore(toastContainer, bottomArea.firstChild);
+    observeOriginContainer(commentNode, originContainer, toastContainer);
+    toastContainer.addEventListener("click", () => {
+        originContainer.insertBefore(commentNode, originContainer.lastElementChild);
+        originContainer.scrollIntoView({ behavior: "smooth", block: "center" });
+        toastContainer.remove();
+    }, { capture: true });
 };
-
 // MARK: MutationObserver가 2번 호출되는 버그 방지
 let isContainerLoaded = false;
-
 const commentsContainerLoaded = (mutationsList, observer) => {
-  for (const mutation of mutationsList) {
-    if (mutation.target.id === "comments") {
-      if (isContainerLoaded) return;
-
-      const commentsContainer = mutation.target.querySelector("#contents");
-      if (commentsContainer) {
-        commentsContentObserver.observe(commentsContainer, {
-          childList: true,
-          subtree: true,
-        });
-        isContainerLoaded = true;
-      }
-
-      observer.disconnect();
+    for (const mutation of mutationsList) {
+        const target = mutation.target;
+        if (target.id === "comments") {
+            if (isContainerLoaded)
+                return;
+            const commentsContainer = target.querySelector("#contents");
+            if (commentsContainer) {
+                commentsContentObserver.observe(commentsContainer, {
+                    childList: true,
+                    subtree: true,
+                });
+                isContainerLoaded = true;
+            }
+            observer.disconnect();
+        }
     }
-  }
 };
-
-const commentsContentLoaded = (mutationsList, observer) => {
-  for (const mutation of mutationsList) {
-    if (mutation.target.tagName === "YTD-COMMENT-THREAD-RENDERER") {
-      const thread = mutation.target;
-      const content = thread.querySelector("#comment-content");
-
-      if (!content) continue;
-
-      const links = content.querySelectorAll("a");
-      const timestamps = [...links].filter((a) =>
-        a.getAttribute("href")?.startsWith("/watch?v")
-      );
-
-      if (timestamps.length > 0) {
-        timestamps.forEach((timestamp) => {
-          // timestamp.style.color = "orange";
-          timestamp.addEventListener("click", () =>
-            handleClickTimeStamp(content, thread.querySelector("#main"))
-          );
-        });
-      }
-      // TODO: 언제 호출해야 하는지?
-      // observer.disconnect();
+const commentsContentLoaded = (mutationsList) => {
+    for (const mutation of mutationsList) {
+        const target = mutation.target;
+        if (target.tagName === "YTD-COMMENT-THREAD-RENDERER") {
+            const thread = target;
+            const content = thread.querySelector("#comment-content");
+            if (!content)
+                continue;
+            const links = content.querySelectorAll("a");
+            const timestamps = [...links].filter((a) => { var _a; return (_a = a.getAttribute("href")) === null || _a === void 0 ? void 0 : _a.startsWith("/watch?v"); });
+            if (timestamps.length > 0) {
+                timestamps.forEach((timestamp) => {
+                    // timestamp.style.color = "orange";
+                    timestamp.addEventListener("click", () => handleClickTimeStamp(content, thread.querySelector("#main")));
+                });
+            }
+            // TODO: 언제 호출해야 하는지?
+            // observer.disconnect();
+        }
     }
-  }
 };
-
 const commentsContainerObserver = new MutationObserver(commentsContainerLoaded);
 const commentsContentObserver = new MutationObserver(commentsContentLoaded);

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -20,14 +20,6 @@ const observeOriginContainer = (commentNode, originContainer, toastContainer) =>
     }, options);
     observer.observe(originContainer);
 };
-// const append = (target, parent) => {
-//   console.debug("불러짐?");
-//   console.debug("target", target);
-//   console.debug("parent", parent);
-//   toastContainer.innerHTML = "aweifjaweoifjwaefoiwaeofjwfei";
-//   console.debug(toastContainer);
-//   parent.appendChild(target.cloneNode());
-// };
 const handleClickTimeStamp = (commentNode, originContainer) => {
     // MARK: copy할 수 있는 방안을 찾기
     const bottomArea = document.querySelector("div#below");
@@ -36,15 +28,14 @@ const handleClickTimeStamp = (commentNode, originContainer) => {
     toastContainer.addEventListener("mouseover", () => {
         toastContainer.style.background = "rgba(50, 166, 255, 0.2)";
     });
-    // toastContainer.addEventListener("mouseout", () => {
-    //   toastContainer.style.background = "none";
-    // });
-    console.debug("toast containerr ", toastContainer);
-    console.debug("commentNode", commentNode);
-    // append(commentNode, toastContainer);
+    toastContainer.addEventListener("mouseout", () => {
+        toastContainer.style.background = "none";
+    });
     toastContainer.appendChild(commentNode);
     bottomArea.insertBefore(toastContainer, bottomArea.firstChild);
-    observeOriginContainer(commentNode, originContainer, toastContainer);
+    setTimeout(() => {
+        observeOriginContainer(commentNode, originContainer, toastContainer);
+    }, 1000);
     toastContainer.addEventListener("click", () => {
         originContainer.insertBefore(commentNode, originContainer.lastElementChild);
         originContainer.scrollIntoView({ behavior: "smooth", block: "center" });

--- a/src/main.ts
+++ b/src/main.ts
@@ -48,7 +48,9 @@ const handleClickTimeStamp = (commentNode: HTMLElement, originContainer: HTMLEle
   toastContainer.appendChild(commentNode);
   bottomArea.insertBefore(toastContainer, bottomArea.firstChild);
 
-  observeOriginContainer(commentNode, originContainer, toastContainer);
+  setTimeout(() => {
+    observeOriginContainer(commentNode, originContainer, toastContainer);
+  }, 1000);
 
   toastContainer.addEventListener(
     "click",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,116 @@
+document.addEventListener("DOMContentLoaded", () => {
+  commentsContainerObserver.observe(document.body, {
+    childList: true,
+    subtree: true,
+  });
+});
+
+const observeOriginContainer = (
+  commentNode: HTMLElement,
+  originContainer: HTMLElement,
+  toastContainer: HTMLElement
+) => {
+  const options = {
+    threshold: 1.0,
+  };
+
+  const observer = new IntersectionObserver((entries, observer) => {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) {
+        originContainer.insertBefore(commentNode, originContainer.lastElementChild);
+        toastContainer.remove();
+        observer.unobserve(originContainer);
+      }
+    });
+  }, options);
+
+  observer.observe(originContainer);
+};
+
+const handleClickTimeStamp = (commentNode: HTMLElement, originContainer: HTMLElement) => {
+  // MARK: copy할 수 있는 방안을 찾기
+  const bottomArea = document.querySelector("div#below") as HTMLElement;
+  const toastContainer = document.createElement("div");
+
+  toastContainer.setAttribute(
+    "style",
+    "width: 100%; border: 2px dashed #32A6FF; margin-top: 12px; padding: 12px; box-sizing: border-box; border-radius: 12px; cursor: pointer;"
+  );
+
+  toastContainer.addEventListener("mouseover", () => {
+    toastContainer.style.background = "rgba(50, 166, 255, 0.2)";
+  });
+
+  toastContainer.addEventListener("mouseout", () => {
+    toastContainer.style.background = "none";
+  });
+
+  toastContainer.appendChild(commentNode);
+  bottomArea.insertBefore(toastContainer, bottomArea.firstChild);
+
+  observeOriginContainer(commentNode, originContainer, toastContainer);
+
+  toastContainer.addEventListener(
+    "click",
+    () => {
+      originContainer.insertBefore(commentNode, originContainer.lastElementChild);
+      originContainer.scrollIntoView({ behavior: "smooth", block: "center" });
+      toastContainer.remove();
+    },
+    { capture: true }
+  );
+};
+
+// MARK: MutationObserver가 2번 호출되는 버그 방지
+let isContainerLoaded = false;
+
+const commentsContainerLoaded: MutationCallback = (mutationsList, observer) => {
+  for (const mutation of mutationsList) {
+    const target = mutation.target as HTMLElement;
+
+    if ((target as HTMLElement).id === "comments") {
+      if (isContainerLoaded) return;
+
+      const commentsContainer = target.querySelector("#contents");
+      if (commentsContainer) {
+        commentsContentObserver.observe(commentsContainer, {
+          childList: true,
+          subtree: true,
+        });
+        isContainerLoaded = true;
+      }
+
+      observer.disconnect();
+    }
+  }
+};
+
+const commentsContentLoaded: MutationCallback = (mutationsList) => {
+  for (const mutation of mutationsList) {
+    const target = mutation.target as HTMLElement;
+
+    if (target.tagName === "YTD-COMMENT-THREAD-RENDERER") {
+      const thread = target;
+      const content = thread.querySelector("#comment-content") as HTMLElement;
+
+      if (!content) continue;
+
+      const links = content.querySelectorAll("a");
+      const timestamps = [...links].filter((a) => a.getAttribute("href")?.startsWith("/watch?v"));
+
+      if (timestamps.length > 0) {
+        timestamps.forEach((timestamp) => {
+          // timestamp.style.color = "orange";
+          timestamp.addEventListener("click", () =>
+            handleClickTimeStamp(content, thread.querySelector("#main") as HTMLElement)
+          );
+        });
+      }
+      // TODO: 언제 호출해야 하는지?
+      // observer.disconnect();
+    }
+  }
+};
+
+const commentsContainerObserver = new MutationObserver(commentsContainerLoaded);
+const commentsContentObserver = new MutationObserver(commentsContentLoaded);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+   "target": "ES6",
+   "module": "ES2015",
+   "lib": ["DOM", "DOM.Iterable","ESNext"],
+   "allowJs": true,
+   "outDir": "./scripts", 
+   "rootDir": "./src",
+   "strict": true,
+   "noImplicitAny": true, 
+   "strictNullChecks": true,
+   "strictFunctionTypes": true, 
+   "strictPropertyInitialization": true,
+   "noImplicitThis": true,
+   "alwaysStrict": true,
+   "noUnusedLocals": true,
+   "noUnusedParameters": true,
+   "noImplicitReturns": true,
+   "noFallthroughCasesInSwitch": true, 
+  }
+ }


### PR DESCRIPTION
## 주요 변경사항

- 타입스크립트를 넣었습니다.
  - npm run tsc를 통해서 scripts 폴더에 main.js를 생성하게 했습니다.
  - src 폴더를 만들어서 main.ts파일을 두었습니다.

 
- 본래의 코멘트 컨테이너에 intersectionObserver 적용하는 것을 setTimeout으로 의도적으로 딜레이를 두게 했습니다.

## 문제상황

타입스탬프 클릭 시 originContainer에 observer가 걸리면서 originContainer에 접근 시 toastContainer를 지우는데, 타임스탬프를 클릭 후 스크롤이 올라가는 과정에 이미 observer가 걸리면서, toastContainer가 삭제됨.

### as-is

![화면 기록 2023-02-27 오전 12 45 29](https://user-images.githubusercontent.com/49264892/221421306-b39f353e-f3b1-4ebc-baf6-671790bf255a.gif)



### to-be

![화면 기록 2023-02-27 오전 12 46 19](https://user-images.githubusercontent.com/49264892/221421274-90c6b91f-8a4a-4c14-a9d0-1145341ce6b0.gif)